### PR TITLE
Throw different exceptions to indicate the type of parse error

### DIFF
--- a/ubxtranslator/core.py
+++ b/ubxtranslator/core.py
@@ -290,13 +290,13 @@ class Message:
                 break
 
             if fmt_len > payload_len:
-                raise IOError('The payload length does not match the length implied by the message fields. ' +
+                raise ValueError('The payload length does not match the length implied by the message fields. ' +
                                  'Expected {} actual {}'.format(struct.calcsize(self.fmt), payload_len))
 
             try:
                 self._repeated_block.repeat += 1
             except AttributeError:
-                raise IOError('The payload length does not match the length implied by the message fields. ' +
+                raise ValueError('The payload length does not match the length implied by the message fields. ' +
                                  'Expected {} actual {}'.format(struct.calcsize(self.fmt), payload_len))
 
 
@@ -394,13 +394,15 @@ class Parser:
 
     async def async_receive_from(self, stream) -> namedtuple:
         """Receive a message from a stream and return as a namedtuple.
-        raise IOError or ValueError on errors.
+        raise IOError in case of errors due to insufficient data.
+        raise ValueError in case of errors due to sufficient but invalid data.
         """
         pass
 
     def receive_from(self, stream) -> namedtuple:
         """Receive a message from a stream and return as a namedtuple.
-        raise IOError or ValueError on errors.
+        raise IOError in case of errors due to insufficient data.
+        raise ValueError in case of errors due to sufficient but invalid data.
         """
         while True:
             # Search for the prefix

--- a/ubxtranslator/tests/test_core.py
+++ b/ubxtranslator/tests/test_core.py
@@ -215,8 +215,8 @@ class UbxParserTester(unittest.TestCase):
 
                 parser.receive_from(test_stream)
 
-        with self.subTest(msg='Test bad length'):
-            with self.assertRaises(IOError):
+        with self.subTest(msg='Test bad length with sufficient data'):
+            with self.assertRaises(ValueError):
                 test_packet = bytes([1, 1, 7, 0, 0, 1, 2, 3, 4, 5])
                 test_packet = parser.PREFIX + test_packet + parser._generate_fletcher_checksum(test_packet)
 
@@ -224,7 +224,7 @@ class UbxParserTester(unittest.TestCase):
 
                 parser.receive_from(test_stream)
 
-        with self.subTest(msg='Test bad length'):
+        with self.subTest(msg='Test bad length with insufficient data'):
             with self.assertRaises(IOError):
                 test_packet = bytes([1, 1, 6, 0, 0, 1, 2, 3, 5])
                 test_packet = parser.PREFIX + test_packet + parser._generate_fletcher_checksum(test_packet)


### PR DESCRIPTION
Use `IOError` to indicate errors caused by insufficient data and `ValueError` to indicate that there was sufficient data but that it is invalid.  This enables the parser to be used for streaming use cases where UBX data is being received in real-time - in the case of `IOError`, the caller is informed that it should retry when more data becomes available, but in the case of `ValueError` the message should be discarded.