### PR TITLE
Add support for UBX-NAV-HPPOSLLH.flags field

### DIFF
--- a/ubxtranslator/predefined.py
+++ b/ubxtranslator/predefined.py
@@ -98,7 +98,10 @@ NAV_CLS = core.Cls(0x01, 'NAV', [
     ]),
     core.Message(0x14, 'HPPOSLLH', [
         core.Field('version', 'U1'),
-        core.PadByte(repeat=2),
+        core.PadByte(repeat=1),
+        core.BitField('flags', 'X1', [
+            core.Flag('invalidLlh', 0, 1),
+        ]),
         core.Field('iTOW', 'U4'),
         core.Field('lon', 'I4'),
         core.Field('lat', 'I4'),


### PR DESCRIPTION
Per page 99 of https://www.u-blox.com/docs/UBX-21019746: byte 3 of the UBX-NAV-HPPOSLLH message contains a bitfield called `flags` which contains a single flag named `invalidLlh`